### PR TITLE
PG support, plus fixes for rake

### DIFF
--- a/lib/active_record/connection_adapters/makara_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_adapter.rb
@@ -48,7 +48,7 @@ module ActiveRecord
       attr_reader :current_wrapper
 
       SQL_SLAVE_KEYWORDS      = ['select', 'show tables', 'show fields', 'describe', 'show database', 'show schema', 'show view', 'show index']
-      SQL_SLAVE_MATCHER       = /^(#{SQL_SLAVE_KEYWORDS.join('|')})/
+      SQL_SLAVE_MATCHER       = /^\s*(#{SQL_SLAVE_KEYWORDS.join('|')})/
 
       MASS_DELEGATION_METHODS = %w(reconnect! disconnect! reset!)
       MASS_ANY_DELEGATION_METHODS = %w(active?)

--- a/lib/active_record/connection_adapters/makara_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_adapter.rb
@@ -4,9 +4,14 @@ module ActiveRecord
 
     def self.makara_connection(config)
       wrappers = ::Makara::ConfigParser.each_config(config) do |db_config|
-        connection = underlying_connection_for(db_config)                
-        ::Makara::Connection::Wrapper.new(connection)
-      end
+        begin
+          connection = underlying_connection_for(db_config)
+          ::Makara::Connection::Wrapper.new(connection)
+        rescue StandardError => e
+          raise e if db_config[:role] == 'master'
+          nil
+        end
+      end.compact
 
       raise "[Makara] You must include at least one connection that serves as a master" unless wrappers.any?(&:master?)
 

--- a/lib/active_record/connection_adapters/makara_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_adapter.rb
@@ -172,6 +172,7 @@ module ActiveRecord
       # if we want to unstick the current connection (request is over, testing, etc)
       def unstick!
         Makara.info("Unstuck: #{@current_wrapper}")
+        unforce_master!
         @stuck_on = nil
       end
 
@@ -192,6 +193,11 @@ module ActiveRecord
       def force_master!
         @master_forced = true
         Makara.info("Forcing master")
+      end
+
+      def unforce_master!
+        Makara.info("Unforcing master") if @master_forced
+        @master_forced = false
       end
 
       def any_master_connection

--- a/lib/makara/connection/error_handler.rb
+++ b/lib/makara/connection/error_handler.rb
@@ -44,7 +44,7 @@ module Makara
         message = message.to_s.downcase
 
         case message
-        when /(closed|lost|no)\s?(\w+)? connection/, /gone away/, /connection (not open|is closed)/i, /reset has failed/
+        when /(closed|lost|no)\s?(\w+)? connection/, /gone away/, /connection (not open|is closed)/i, /reset has failed/, /the database system is starting up/
           true
         else
           false

--- a/lib/makara/connection/error_handler.rb
+++ b/lib/makara/connection/error_handler.rb
@@ -52,7 +52,8 @@ module Makara
              /no connection to the server/, 
              /could not connect to server/, 
              /result has been cleared/,
-             /terminating connection/
+             /terminating connection/,
+             /pg::error: : select/ # sometimes libpq returns the given sql query as the error message
           true
         else
           false

--- a/lib/makara/connection/error_handler.rb
+++ b/lib/makara/connection/error_handler.rb
@@ -50,9 +50,10 @@ module Makara
              /reset has failed/, 
              /the database system is (starting up|shutting down)/, 
              /no connection to the server/, 
-             /could not connect to server/, 
+             /(could not|cannot) connect to server/,
              /result has been cleared/,
              /terminating connection/,
+             /no more connections allowed/,
              /pg::error: : select/ # sometimes libpq returns the given sql query as the error message
           true
         else

--- a/lib/makara/connection/error_handler.rb
+++ b/lib/makara/connection/error_handler.rb
@@ -44,7 +44,7 @@ module Makara
         message = message.to_s.downcase
 
         case message
-        when /(closed|lost|no)\s?(\w+)? connection/, /gone away/, /connection (not open|is closed)/i, /reset has failed/, /the database system is starting up/, /no connection to the server/, /could not connect to server/, /result has been cleared/
+        when /(closed|lost|no)\s?(\w+)? connection/, /gone away/, /connection (not open|is closed)/i, /reset has failed/, /the database system is (starting up|shutting down)/, /no connection to the server/, /could not connect to server/, /result has been cleared/
           true
         else
           false

--- a/lib/makara/connection/error_handler.rb
+++ b/lib/makara/connection/error_handler.rb
@@ -44,7 +44,7 @@ module Makara
         message = message.to_s.downcase
 
         case message
-        when /(closed|lost|no)\s?(\w+)? connection/, /gone away/, /connection (not open|is closed)/i, /reset has failed/, /the database system is starting up/
+        when /(closed|lost|no)\s?(\w+)? connection/, /gone away/, /connection (not open|is closed)/i, /reset has failed/, /the database system is starting up/, /no connection to the server/, /could not connect to server/, /result has been cleared/
           true
         else
           false

--- a/lib/makara/connection/error_handler.rb
+++ b/lib/makara/connection/error_handler.rb
@@ -44,7 +44,7 @@ module Makara
         message = message.to_s.downcase
 
         case message
-        when /(closed|lost|no)\s?(\w+)? connection/, /gone away/
+        when /(closed|lost|no)\s?(\w+)? connection/, /gone away/, /connection (not open|is closed)/i, /reset has failed/
           true
         else
           false

--- a/lib/makara/connection/error_handler.rb
+++ b/lib/makara/connection/error_handler.rb
@@ -44,7 +44,15 @@ module Makara
         message = message.to_s.downcase
 
         case message
-        when /(closed|lost|no)\s?(\w+)? connection/, /gone away/, /connection (not open|is closed)/i, /reset has failed/, /the database system is (starting up|shutting down)/, /no connection to the server/, /could not connect to server/, /result has been cleared/
+        when /(closed|lost|no)\s?(\w+)? connection/, 
+             /gone away/, 
+             /connection (not open|is closed)/i, 
+             /reset has failed/, 
+             /the database system is (starting up|shutting down)/, 
+             /no connection to the server/, 
+             /could not connect to server/, 
+             /result has been cleared/,
+             /terminating connection/
           true
         else
           false

--- a/lib/makara/railtie.rb
+++ b/lib/makara/railtie.rb
@@ -10,5 +10,8 @@ module Makara
       end
     end
 
+    rake_tasks do
+      load "makara/railties/database.rake"
+    end
   end
 end

--- a/lib/makara/railties/database.rake
+++ b/lib/makara/railties/database.rake
@@ -1,0 +1,44 @@
+namespace :db do
+  task :load_config => ['makara:mask_adapter']
+  task :drop => ['makara:mask_adapter']
+  task :create => ['makara:mask_adapter']
+  task :charset => ['makara:mask_adapter']
+  
+  namespace :schema do
+    task :dump => ['makara:mask_adapter']
+    task :load => ['makara:mask_adapter']
+  end
+
+  namespace :structure do
+    task :dump => ['makara:mask_adapter']
+    task :load => ['makara:mask_adapter']
+  end
+
+  namespace :drop do
+    task :all => ['makara:mask_adapter']
+  end
+
+  namespace :create do
+    task :all => ['makara:mask_adapter']
+  end
+
+  namespace :test do
+    task :purge => ['makara:mask_adapter']
+  end
+end
+
+namespace :makara do
+  desc "force rake tasks to use pass-through db adapter"
+  task :mask_adapter do
+    Rails.application.config.database_configuration.each_pair do |env, config|
+      if config["adapter"] == "makara"
+        adapter = config["db_adapter"]
+
+        config['adapter'] = adapter
+
+        ActiveRecord::Base.configurations[env]["adapter"] = adapter if defined?(ActiveRecord::Base) && ActiveRecord::Base.configurations[env]
+      end
+    end
+    Rake::Task["makara:mask_adapter"].reenable
+  end
+end

--- a/makara.gemspec
+++ b/makara.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Makara::VERSION
 
-  gem.add_dependency 'rails', '>= 3.0'
+  gem.add_dependency 'activerecord', '>= 3.0'
 end

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -38,4 +38,26 @@ describe ActiveRecord::ConnectionAdapters::MakaraAdapter do
 
   end
 
+  describe 'establishing connections' do
+    let(:base_config) { {:adapter => 'abstract', :database => 'test_db', :host => 'localhost', :port => '3439'} }
+    let(:master_config) { base_config.merge({:name => 'master', :role => 'master'}) }
+    let(:slave_config) { base_config.merge({:name => 'slave1'}) }
+
+    context 'when a slave is down' do
+      it 'skips the slave without an error' do
+        ActiveRecord::Base.should_receive(:abstract_connection).with(master_config).and_call_original
+        ActiveRecord::Base.should_receive(:abstract_connection).with(slave_config).and_raise(ActiveRecord::ConnectionNotEstablished)
+        expect { ActiveRecord::Base.makara_connection(config) }.not_to raise_error
+      end
+    end
+
+    context 'when a master is down' do
+      it 'raises error from connection attempt' do
+        ActiveRecord::Base.should_receive(:abstract_connection).with(master_config).and_raise(ActiveRecord::ConnectionNotEstablished)
+        ActiveRecord::Base.should_receive(:abstract_connection).with(slave_config).never
+        expect { ActiveRecord::Base.makara_connection(config) }.to raise_error(ActiveRecord::ConnectionNotEstablished)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Here is some additional error handling to make makara work with the postgresql adapter.

We also found that some activerecord rake tasks asplode when you use any database adapter other than mysql, postgresql, sqlite or something called firebird. These are matched by duplicated case statements scattered throughout the activerecord rake files, and which are impossible to extend without hard-coding new adapters in.

We added some rake tasks which rewrite the activerecord configurations when running these AR tasks, to fake as if it is not there. This works for our deployment, but there may be other stray tasks which we missed.
