### PR TITLE
Registering adapters with the same ID no longer raises, but does not add...

### DIFF
--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -38,8 +38,7 @@ module Makara
 
     def register_adapter(adapter)
       @adapters ||= []
-      raise "[Makara] all adapters must be given a unique id. \"#{adapter.id}\" has already been used." if @adapters.map(&:id).include?(adapter.id)
-      @adapters << adapter
+      @adapters << adapter unless @adapters.map(&:id).include?(adapter.id)
       @adapters = @adapters.sort_by(&:id)
     end
 

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -74,10 +74,15 @@ describe ActiveRecord::ConnectionAdapters::MakaraAdapter do
       Makara.adapters.should eql([adapter])
     end
 
-    it 'should not allow multiple adapters with the same id' do
+    it 'should not raise if multiple adapters with the same id are registered' do
       lambda{
         ActiveRecord::ConnectionAdapters::MakaraAdapter.new([adapter.mcon])
-      }.should raise_error('[Makara] all adapters must be given a unique id. "default" has already been used.')
+      }.should_not raise_error
+    end
+
+    it 'should not allow multiple adapters with the same id to be registered' do
+      ActiveRecord::ConnectionAdapters::MakaraAdapter.new([adapter.mcon])
+      Makara.adapters.should eql([adapter])
     end
 
     it 'should allow multiple adapters as long as they have different id' do


### PR DESCRIPTION
This allows an adapter to be registered again without raising an error - beyond the first, subsequent attempts are silently discarded. There doesn't seem to be any value in raising the error beyond ensuring that the @adapters array contains only unique adapters. I noticed this when, in a setup with a master/slave postgresql pair, Makara seemed to try to register every time an ActiveRecord connection was made. 
