### PR TITLE
Pass instance_variable_get through to the master connection

### DIFF
--- a/lib/active_record/connection_adapters/makara_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_adapter.rb
@@ -42,7 +42,11 @@ module ActiveRecord
         "ActiveRecord::ConnectionAdapters::#{adapter_name.to_s.classify}Adapter".constantize.visitor_for(pool)
       end
 
-      attr_reader :current_wrapper, :id
+      undef_method :instance_variable_get
+
+      attr_reader :current_wrapper
+      attr_reader :id
+      attr_reader :exception_handler
 
       SQL_SLAVE_KEYWORDS      = ['select', 'show tables', 'show fields', 'describe', 'show database', 'show schema', 'show view', 'show index']
       SQL_SLAVE_MATCHER       = /^(#{SQL_SLAVE_KEYWORDS.join('|')})/

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -88,4 +88,13 @@ describe ActiveRecord::ConnectionAdapters::MakaraAdapter do
 
   end
 
+  context "retrieving instance variables" do
+
+    it 'should pass to the master adapter' do
+      adapter.class.public_instance_methods.map(&:to_s).should_not include('instance_variable_get')
+      adapter.instance_variable_get(:@config).object_id.should eql(adapter.mcon.instance_variable_get(:@config).object_id)
+    end
+
+  end
+
 end

--- a/spec/error_handler_spec.rb
+++ b/spec/error_handler_spec.rb
@@ -7,7 +7,7 @@ describe Makara::Connection::ErrorHandler do
   end
 
   let(:config){ single_slave_config }
-  let(:handler){ adapter.instance_variable_get('@exception_handler') }
+  let(:handler){ adapter.exception_handler }
 
   [
     %|Mysql::Error: : INSERT INTO `watchers` (`user_id`, `watchable_id`, `watchable_type`) VALUES|,


### PR DESCRIPTION
Many other libraries do things like `ActiveRecord::Base.connection.instance_variable_get('@config')` - this will provide that compatibility by passing all instance_variable_get invocations to the master connection.
