### PR TITLE
Fixes double quotes for no ruby eval & cleans as per ruby style guide

### DIFF
--- a/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
@@ -15,7 +15,7 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter::ErrorHandler d
       expect(handler).not_to be_connection_message(msg)
     end
 
-    it "should raise the error" do
+    it 'should raise the error' do
       expect{
         handler.handle(connection) do
           raise msg
@@ -34,7 +34,7 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter::ErrorHandler d
       expect(handler).to be_connection_message(msg)
     end
 
-    it "should blacklist the connection" do
+    it 'should blacklist the connection' do
       expect {
         handler.handle(connection) do
           raise msg

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
@@ -6,21 +6,21 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
   let(:klass){ FakeAdapter }
 
   {
-    "insert into dogs..." => true,
-    "insert into cats (select * from felines)" => true,
-    "savepoint active_record_1" => true,
-    "begin" => true,
-    "rollback" => true,
-    "update users set" => true,
-    "delete from people" => true,
-    "release savepoint" => true,
-    "show tables" => true,
-    "show fields" => true,
-    "describe table" => true,
-    "show index" => true,
-    "set @@things" => true,
-    "commit" => true,
-    "select * from felines" => false
+    'insert into dogs...' => true,
+    'insert into cats (select * from felines)' => true,
+    'savepoint active_record_1' => true,
+    'begin' => true,
+    'rollback' => true,
+    'update users set' => true,
+    'delete from people' => true,
+    'release savepoint' => true,
+    'show tables' => true,
+    'show fields' => true,
+    'describe table' => true,
+    'show index' => true,
+    'set @@things' => true,
+    'commit' => true,
+    'select * from felines' => false
   }.each do |sql, should_go_to_master|
 
     it "determines if \"#{sql}\" #{should_go_to_master ? 'requires' : 'does not require'} master" do
@@ -43,26 +43,26 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
   end
 
   {
-    "show full tables" => false,
-    "show full table" => false,
-    "show index" => false,
-    "show indexes" => false,
-    "describe stuff" => false,
-    "explain things" => false,
-    "show database" => false,
-    "show schema" => false,
-    "show view" => false,
-    "show views" => false,
-    "show table" => false,
-    "show tables" => false,
-    "set @@things" => false,
-    "update users" => true,
-    "insert into" => true,
-    "delete from" => true,
-    "begin transaction" => true,
-    "begin deferred transaction" => true,
-    "commit transaction" => true,
-    "rollback transaction" => true
+    'show full tables' => false,
+    'show full table' => false,
+    'show index' => false,
+    'show indexes' => false,
+    'describe stuff' => false,
+    'explain things' => false,
+    'show database' => false,
+    'show schema' => false,
+    'show view' => false,
+    'show views' => false,
+    'show table' => false,
+    'show tables' => false,
+    'set @@things' => false,
+    'update users' => true,
+    'insert into' => true,
+    'delete from' => true,
+    'begin transaction' => true,
+    'begin deferred transaction' => true,
+    'commit transaction' => true,
+    'rollback transaction' => true
   }.each do |sql,should_stick|
 
     it "should #{should_stick ? 'stick' : 'not stick'} to master if handling sql like \"#{sql}\"" do

--- a/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
@@ -13,7 +13,7 @@ describe 'MakaraMysql2Adapter' do
     expect(ActiveRecord::Base.connection).to be_instance_of(ActiveRecord::ConnectionAdapters::MakaraMysql2Adapter)
   end
 
-  context "with the connection established" do
+  context 'with the connection established' do
 
     before do
       ActiveRecord::Base.establish_connection(config)

--- a/spec/pool_spec.rb
+++ b/spec/pool_spec.rb
@@ -112,10 +112,10 @@ describe Makara::Pool do
 
   it 'skips blacklisted connections when choosing the next one' do
 
-    wrapper_a = pool.add 'a', pool_config
-    wrapper_b = pool.add 'b', pool_config
-    wrapper_c = pool.add 'c', pool_config
+    pool.add 'a', pool_config
+    pool.add 'c', pool_config
 
+    wrapper_b = pool.add 'b', pool_config
     wrapper_b._makara_blacklist!
 
     10.times{ pool.provide{|connection| expect(connection.to_s).not_to eq('b') } }

--- a/spec/proxy_spec.rb
+++ b/spec/proxy_spec.rb
@@ -13,33 +13,33 @@ describe Makara::Proxy do
 
 
   it 'sets up a master and slave pool no matter the number of connections' do
-    proxy = klass.new(config(0,0))
+    proxy = klass.new(config(0, 0))
     expect(proxy.master_pool).to be_a(Makara::Pool)
     expect(proxy.slave_pool).to be_a(Makara::Pool)
 
-    proxy = klass.new(config(2,0))
+    proxy = klass.new(config(2, 0))
     expect(proxy.master_pool).to be_a(Makara::Pool)
     expect(proxy.slave_pool).to be_a(Makara::Pool)
 
-    proxy = klass.new(config(0,2))
+    proxy = klass.new(config(0, 2))
     expect(proxy.master_pool).to be_a(Makara::Pool)
     expect(proxy.slave_pool).to be_a(Makara::Pool)
 
-    proxy = klass.new(config(2,2))
+    proxy = klass.new(config(2, 2))
     expect(proxy.master_pool).to be_a(Makara::Pool)
     expect(proxy.slave_pool).to be_a(Makara::Pool)
   end
 
 
   it 'instantiates N connections within each pool' do
-    proxy = klass.new(config(1,2))
+    proxy = klass.new(config(1, 2))
 
     expect(proxy.master_pool.connection_count).to eq(1)
     expect(proxy.slave_pool.connection_count).to eq(2)
   end
 
   it 'should delegate any unknown method to a connection in the master pool' do
-    proxy = klass.new(config(1,2))
+    proxy = klass.new(config(1, 2))
 
     con = proxy.master_pool.connections.first
     allow(con).to receive(:irespondtothis){ 'hello!' }
@@ -49,7 +49,7 @@ describe Makara::Proxy do
   end
 
 
-  context "#appropriate_pool" do
+  context '#appropriate_pool' do
 
     let(:proxy){ klass.new(config(1,1)) }
 

--- a/spec/support/proxy_extensions.rb
+++ b/spec/support/proxy_extensions.rb
@@ -1,21 +1,7 @@
 module ProxyExtensions
 
-  def master_pool
-    @master_pool
-  end
-
-  def slave_pool
-    @slave_pool
-  end
-
-  def master_context
-    @master_context
-  end
-
-  def id
-    @id
-  end
-
+  attr_reader :master_pool, :slave_pool, :master_context, :id
+  
   def master_for?(sql)
     pool_for(sql) == master_pool
   end


### PR DESCRIPTION
- Removes double quotes for no ruby eval
- Adds space after comma
- Replace trivial methods with attr reader
