### PR TITLE
Force Master Manually / Middleware Context via Query Params

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ Makara::Cache.store = MyRedisCacheStore.new
 
 To handle persistence of context across requests in a Rack app, makara provides a middleware. It lays a cookie named `_mkra_ctxt` which contains the current master context. If the next request is executed before the cookie expires, master will be used. If something occurs which naturally requires master on the second request, the context is changed and stored again.
 
+### Forcing Master
+
+If you need to force master in your app then you can simply invoke stick_to_master! on your connection:
+
+```ruby
+write_to_cache = true # or false
+proxy.stick_to_master(write_to_cache)
+```
+
 ## ActiveRecord Database Adapter
 
 So you've found yourself with an ActiveRecord-based project which is starting to get some traffic and you realize 95% of you DB load is from reads. Well you've come to the right spot. Makara is a great solution to break up that load not only between master and slave but potentially multiple masters and/or multiple slaves.

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -60,6 +60,10 @@ module Makara
       @hijacked
     end
 
+    def stick_to_master!(write_to_cache = true)
+      @master_context = Makara::Context.get_current
+      Makara::Cache.write("makara::#{@master_context}-#{@id}", '1', @ttl) if write_to_cache
+    end
 
     protected
 
@@ -153,8 +157,7 @@ module Makara
       return unless @sticky
       return unless should_stick?(method_name, args)
       return if @master_context == Makara::Context.get_current
-      @master_context = Makara::Context.get_current
-      Makara::Cache.write("makara::#{@master_context}-#{@id}", '1', @ttl) if write_to_cache
+      stick_to_master!(write_to_cache)
     end
 
 

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -13,7 +13,7 @@ describe Makara::Middleware do
   let(:proxy){ FakeProxy.new(config(1,2)) }
   let(:middleware){ described_class.new(app) }
 
-  let(:key){ Makara::Middleware::COOKIE_NAME }
+  let(:key){ Makara::Middleware::IDENTIFIER }
 
   it 'should set the context before the request' do
     Makara::Context.set_previous 'old'
@@ -31,6 +31,17 @@ describe Makara::Middleware do
 
   it 'should use the cookie-provided context if present' do
     env['HTTP_COOKIE'] = "#{key}=abcdefg--200; path=/; max-age=5"
+
+    response = middleware.call(env)
+    current, prev = context_from(response)
+
+    expect(prev).to eq('abcdefg')
+    expect(current).to eq(Makara::Context.get_current)
+    expect(current).not_to eq('abcdefg')
+  end
+
+  it 'should use the param-provided context if present' do
+    env['QUERY_STRING'] = "dog=true&#{key}=abcdefg&cat=false"
 
     response = middleware.call(env)
     current, prev = context_from(response)

--- a/spec/proxy_spec.rb
+++ b/spec/proxy_spec.rb
@@ -48,6 +48,16 @@ describe Makara::Proxy do
     expect(proxy.irespondtothis).to eq('hello!')
   end
 
+  it 'should use master if manually forced' do
+    proxy = klass.new(config(1, 2))
+
+    expect(proxy.master_for?('select * from users')).to eq(false)
+
+    proxy.stick_to_master!
+
+    expect(proxy.master_for?('select * from users')).to eq(true)
+  end
+
 
   context '#appropriate_pool' do
 


### PR DESCRIPTION
By invoking `proxy.stick_to_master!` the proxy will use master until the context changes (next request in a rack app).

If you conduct a request with a query param like `"?_mkra_ctxt=#{digest}"` you'll set the previous context to `digest`, ensuring the request will use master.

Related to #25 
