### PR TITLE
Instantiate Connections on Demand

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -33,7 +33,7 @@ module ActiveRecord
           message = message.to_s.downcase
 
           case message
-          when /(closed|lost|no|terminating|terminated)\s?([^\s]+)?\sconnection/, /gone away/, /connection[^:]+refused/, /could not connect/, /connection[^:]+closed/
+          when /(closed|lost|no|terminating|terminated)\s?([^\s]+)?\sconnection/i, /gone away/i, /connection[^:]+refused/i, /could not connect/i, /connection[^:]+closed/i
             true
           else
             false
@@ -66,13 +66,13 @@ module ActiveRecord
       def appropriate_connection(method_name, args)
         if needed_by_all?(method_name, args)
 
-          @master_pool.each_connection do |con|
+          @master_pool.provide_each do |con|
             hijacked do
               yield con
             end
           end
 
-          @slave_pool.each_connection do |con|
+          @slave_pool.provide_each do |con|
             hijacked do
               yield con
             end

--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -13,10 +13,11 @@ module ActiveRecord
           yield
 
         rescue Exception => e
-
           # do it via class name to avoid version-specific constant dependencies
           case e.class.name
           when 'ActiveRecord::RecordNotUnique', 'ActiveRecord::InvalidForeignKey'
+            harshly(e)
+          when 'Makara::Errors::BlacklistConnection', 'Makara::Errors::InitialConnectionFailure'
             harshly(e)
           else
             if connection_message?(e)
@@ -114,10 +115,6 @@ module ActiveRecord
 
       def connection_for(config)
         active_record_connection_for(config)
-      rescue Exception => e
-        raise unless @config_parser.makara_config[:rescue_connection_failures]
-        raise unless @error_handler.connection_message?(e.message)
-        nil
       end
 
       def active_record_connection_for(config)

--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -14,6 +14,7 @@ module Makara
   module Errors
     autoload :AllConnectionsBlacklisted,  'makara/errors/all_connections_blacklisted'
     autoload :BlacklistConnection,        'makara/errors/blacklist_connection'
+    autoload :InitialConnectionFailure,   'makara/errors/initial_connection_failure'
   end
 
   module Logging

--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -15,6 +15,7 @@ module Makara
     autoload :AllConnectionsBlacklisted,  'makara/errors/all_connections_blacklisted'
     autoload :BlacklistConnection,        'makara/errors/blacklist_connection'
     autoload :InitialConnectionFailure,   'makara/errors/initial_connection_failure'
+    autoload :NoConnectionsAvailable,     'makara/errors/no_connections_available'
   end
 
   module Logging

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -9,10 +9,10 @@ require 'active_support/core_ext/hash/keys'
 module Makara
   class ConnectionWrapper < ::SimpleDelegator
 
-    def initialize(connection_instantiation_block, proxy, config)
+    def initialize(proxy, config, &block)
       super(nil)
 
-      @connection_instantiation_block = connection_instantiation_block
+      @connection_instantiation_block = block
 
       @config = config.symbolize_keys
       @proxy  = proxy

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -19,8 +19,8 @@ module Makara
     end
 
     # if we have been able to secure a connection then evaluate the given block
-    def _makara_is_connected
-      @connection
+    def _makara_connected?
+      !!@connection
     end
 
     def _makara_weight
@@ -70,13 +70,11 @@ module Makara
     def method_missing(method_name, *args, &block)
       super
     rescue NoMethodError => e
-      if _makara_is_connected
-        target = __getobj__
-        if target.respond_to?(method_name, true)
-          target.__send__(method_name, *args, &block)
-        else
-          raise e
-        end
+      target = __getobj__
+      if target.respond_to?(method_name, true)
+        target.__send__(method_name, *args, &block)
+      else
+        raise e
       end
     end
 

--- a/lib/makara/error_handler.rb
+++ b/lib/makara/error_handler.rb
@@ -10,7 +10,13 @@ module Makara
       yield
 
     rescue Exception => e
-      gracefully(connection, e)
+
+      if e.class.name =~ /^Makara::/
+        harshly(e)
+      else
+        gracefully(connection, e)
+      end
+
     end
 
 

--- a/lib/makara/errors/initial_connection_failure.rb
+++ b/lib/makara/errors/initial_connection_failure.rb
@@ -1,0 +1,12 @@
+module Makara
+  module Errors
+    class InitialConnectionFailure < ::StandardError
+
+      def initialize(connection, error)
+        name = connection._makara_name
+        super "[Makara] Failed to instantiate connection: #{name} -> #{error.message}"
+      end
+
+    end
+  end
+end

--- a/lib/makara/errors/no_connections_available.rb
+++ b/lib/makara/errors/no_connections_available.rb
@@ -1,0 +1,14 @@
+module Makara
+  module Errors
+    class NoConnectionsAvailable < ::StandardError
+
+      attr_reader :role
+
+      def initialize(role)
+        @role = role
+        super "[Makara] No connections are available in the #{role} pool"
+      end
+
+    end
+  end
+end

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -79,6 +79,8 @@ module Makara
       @latest_blacklist_error = e
       provided_connection._makara_blacklist!
       retry
+    rescue Makara::Errors::InitialConnectionFailure => e
+      provided_connection._makara_blacklist!
     end
 
 

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -25,10 +25,10 @@ module Makara
 
 
     # Add a connection to this pool, wrapping the connection with a Makara::ConnectionWrapper
-    def add(connection_instantiation_block, config)
+    def add(config, &block)
       config[:name] ||= "#{@role}/#{@connections.length + 1}"
 
-      wrapper = Makara::ConnectionWrapper.new(connection_instantiation_block, @proxy, config)
+      wrapper = Makara::ConnectionWrapper.new(@proxy, config, &block)
       wrapper._makara_weight.times{ @connections << wrapper }
 
       if should_shuffle?

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -25,10 +25,10 @@ module Makara
 
 
     # Add a connection to this pool, wrapping the connection with a Makara::ConnectionWrapper
-    def add(connection, config)
+    def add(connection_instantiation_block, config)
       config[:name] ||= "#{@role}/#{@connections.length + 1}"
 
-      wrapper = Makara::ConnectionWrapper.new(connection, @proxy, config)
+      wrapper = Makara::ConnectionWrapper.new(connection_instantiation_block, @proxy, config)
       wrapper._makara_weight.times{ @connections << wrapper }
 
       if should_shuffle?
@@ -49,7 +49,9 @@ module Makara
 
     def send_to_all(method, *args)
       ret = nil
-      @connections.each{|connection| ret = connection.send(method, *args) }
+      each_connection do |con|
+        ret = con.send(method, *args)
+      end
       ret
     end
 

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -170,14 +170,14 @@ module Makara
     def instantiate_connections
       @master_pool = Makara::Pool.new('master', self)
       @config_parser.master_configs.each do |master_config|
-        con = connection_for(master_config)
-        @master_pool.add con, master_config.merge(@config_parser.makara_config) if con
+        con_proc = Proc.new{ connection_for(master_config) }
+        @master_pool.add con_proc, master_config.merge(@config_parser.makara_config)
       end
 
       @slave_pool = Makara::Pool.new('slave', self)
       @config_parser.slave_configs.each do |slave_config|
-        con = connection_for(slave_config)
-        @slave_pool.add con, slave_config.merge(@config_parser.makara_config) if con
+        con_proc = Proc.new{ connection_for(slave_config) }
+        @slave_pool.add con_proc, slave_config.merge(@config_parser.makara_config)
       end
     end
 

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -170,14 +170,16 @@ module Makara
     def instantiate_connections
       @master_pool = Makara::Pool.new('master', self)
       @config_parser.master_configs.each do |master_config|
-        con_proc = Proc.new{ connection_for(master_config) }
-        @master_pool.add con_proc, master_config.merge(@config_parser.makara_config)
+        @master_pool.add master_config.merge(@config_parser.makara_config) do
+          connection_for(master_config)
+        end
       end
 
       @slave_pool = Makara::Pool.new('slave', self)
       @config_parser.slave_configs.each do |slave_config|
-        con_proc = Proc.new{ connection_for(slave_config) }
-        @slave_pool.add con_proc, slave_config.merge(@config_parser.makara_config)
+        @slave_pool.add slave_config.merge(@config_parser.makara_config) do
+          connection_for(slave_config)
+        end
       end
     end
 

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
@@ -5,7 +5,7 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter::ErrorHandler d
 
   let(:handler){ described_class.new }
   let(:proxy) { FakeAdapter.new(config(1,1)) }
-  let(:connection){ proxy.master_pool.any }
+  let(:connection){ proxy.master_pool.connections.first }
 
   [
     %|Mysql::Error: : INSERT INTO `watchers` (`user_id`, `watchable_id`, `watchable_type`) VALUES|,

--- a/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'active_record/connection_adapters/mysql2_adapter'
 
 describe 'MakaraMysql2Adapter' do
 
@@ -19,46 +20,83 @@ describe 'MakaraMysql2Adapter' do
     Makara::Context.set_current Makara::Context.generate
   end
 
-  it 'should allow a connection to be established' do
-    ActiveRecord::Base.establish_connection(config)
-    expect(ActiveRecord::Base.connection).to be_instance_of(ActiveRecord::ConnectionAdapters::MakaraMysql2Adapter)
-  end
+  context "unconnected" do
 
-  it 'should not blow up if a connection fails' do
-    config['makara']['connections'].select{|h| h['role'] == 'slave' }.each{|h| h['username'] = 'other'}
+    it 'should allow a connection to be established' do
+      ActiveRecord::Base.establish_connection(config)
+      expect(ActiveRecord::Base.connection).to be_instance_of(ActiveRecord::ConnectionAdapters::MakaraMysql2Adapter)
+    end
 
-    require 'active_record/connection_adapters/mysql2_adapter'
+    it 'should not blow up if a connection fails' do
+      config['makara']['connections'].select{|h| h['role'] == 'slave' }.each{|h| h['username'] = 'other'}
 
-    original_method = ActiveRecord::Base.method(:mysql2_connection)
+      original_method = ActiveRecord::Base.method(:mysql2_connection)
 
-    allow(ActiveRecord::Base).to receive(:mysql2_connection) do |config|
-      if config[:username] == 'other'
-        raise "could not connect"
-      else
+      allow(ActiveRecord::Base).to receive(:mysql2_connection) do |config|
+        if config[:username] == 'other'
+          raise "could not connect"
+        else
+          original_method.call(config)
+        end
+      end
+
+      ActiveRecord::Base.establish_connection(config)
+      ActiveRecord::Base.connection
+
+      load(File.dirname(__FILE__) + '/../../support/schema.rb')
+      Makara::Context.set_current Makara::Context.generate
+
+      allow(ActiveRecord::Base).to receive(:mysql2_connection) do |config|
+        config[:username] = db_username
         original_method.call(config)
       end
-    end
 
-    ActiveRecord::Base.establish_connection(config)
-    ActiveRecord::Base.connection
-
-    load(File.dirname(__FILE__) + '/../../support/schema.rb')
-    Makara::Context.set_current Makara::Context.generate
-
-    allow(ActiveRecord::Base).to receive(:mysql2_connection) do |config|
-      config[:username] = db_username
-      original_method.call(config)
-    end
-
-    ActiveRecord::Base.connection.slave_pool.connections.each(&:_makara_whitelist!)
-    ActiveRecord::Base.connection.slave_pool.provide do |con|
-      res = con.execute('SELECT count(*) FROM users')
-      if defined?(JRUBY_VERSION)
-        expect(res[0]).to eq('count(*)' => 0)
-      else
-        expect(res.to_a[0][0]).to eq(0)
+      ActiveRecord::Base.connection.slave_pool.connections.each(&:_makara_whitelist!)
+      ActiveRecord::Base.connection.slave_pool.provide do |con|
+        res = con.execute('SELECT count(*) FROM users')
+        if defined?(JRUBY_VERSION)
+          expect(res[0]).to eq('count(*)' => 0)
+        else
+          expect(res.to_a[0][0]).to eq(0)
+        end
       end
     end
+
+    it 'should execute a send_to_all against master even if no slaves are connected' do
+      ActiveRecord::Base.establish_connection(config)
+      connection = ActiveRecord::Base.connection
+
+      connection.slave_pool.connections.each do |c|
+        allow(c).to receive(:_makara_blacklisted?){ true }
+        allow(c).to receive(:_makara_connected?){ false }
+        expect(c).to receive(:execute).with('SET @t1 = 1').never
+      end
+
+      connection.master_pool.connections.each do |c|
+        expect(c).to receive(:execute).with('SET @t1 = 1')
+      end
+
+      expect{
+        connection.execute('SET @t1 = 1')
+      }.not_to raise_error
+    end
+
+    it 'should execute a send_to_all and raise a NoConnectionsAvailable error' do
+      ActiveRecord::Base.establish_connection(config)
+      connection = ActiveRecord::Base.connection
+
+      (connection.slave_pool.connections | connection.master_pool.connections).each do |c|
+        allow(c).to receive(:_makara_blacklisted?){ true }
+        allow(c).to receive(:_makara_connected?){ false }
+        expect(c).to receive(:execute).with('SET @t1 = 1').never
+      end
+
+      expect{
+        connection.execute('SET @t1 = 1')
+      }.to raise_error(Makara::Errors::NoConnectionsAvailable)
+
+    end
+
   end
 
   context 'with the connection established and schema loaded' do

--- a/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
@@ -54,7 +54,7 @@ describe 'MakaraMysql2Adapter' do
     ActiveRecord::Base.connection.slave_pool.provide do |con|
       res = con.execute('SELECT count(*) FROM users')
       if defined?(JRUBY_VERSION)
-        expect(res[0]['count']).to eq(0)
+        expect(res[0]).to eq('count(*)' => 0)
       else
         expect(res.to_a[0][0]).to eq(0)
       end

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -55,7 +55,11 @@ describe 'MakaraPostgreSQLAdapter' do
     ActiveRecord::Base.connection.slave_pool.connections.each(&:_makara_whitelist!)
     ActiveRecord::Base.connection.slave_pool.provide do |con|
       res = con.execute('SELECT count(*) FROM users')
-      expect(res.to_a[0]['count']).to eq('0')
+      if defined?(JRUBY_VERSION)
+        expect(res.to_a[0]).to eq('count' => 0)
+      else
+        expect(res.to_a[0]).to eq('count' => '0')
+      end
     end
   end
 

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -44,13 +44,19 @@ describe 'MakaraPostgreSQLAdapter' do
     ActiveRecord::Base.establish_connection(config)
     ActiveRecord::Base.connection
 
+    load(File.dirname(__FILE__) + '/../../support/schema.rb')
+    Makara::Context.set_current Makara::Context.generate
+
     allow(ActiveRecord::Base).to receive(:postgresql_connection) do |config|
       config[:username] = db_username
       original_method.call(config)
     end
 
     ActiveRecord::Base.connection.slave_pool.connections.each(&:_makara_whitelist!)
-    ActiveRecord::Base.connection.slave_pool.connections.each(&:adapter_name)
+    ActiveRecord::Base.connection.slave_pool.provide do |con|
+      res = con.execute('SELECT count(*) FROM users')
+      expect(res.to_a[0]['count']).to eq('0')
+    end
   end
 
   context 'with the connection established and schema loaded' do

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -8,6 +8,17 @@ describe 'MakaraPostgreSQLAdapter' do
     base
   }
 
+  before do
+    if ActiveRecord::Base.connected?
+      ActiveRecord::Base.connection.tap do |c|
+        c.master_pool.connections.each(&:_makara_whitelist!)
+        c.slave_pool.connections.each(&:_makara_whitelist!)
+      end
+    end
+    Makara::Context.set_current Makara::Context.generate
+  end
+
+
   it 'should allow a connection to be established' do
     ActiveRecord::Base.establish_connection(config)
     expect(ActiveRecord::Base.connection).to be_instance_of(ActiveRecord::ConnectionAdapters::MakaraPostgreSQLAdapter)
@@ -34,12 +45,14 @@ describe 'MakaraPostgreSQLAdapter' do
 
   context 'with the connection established and schema loaded' do
 
+    let(:connection) { ActiveRecord::Base.connection }
+
     before do
-      load(File.dirname(__FILE__) + '/../../support/schema.rb')
       ActiveRecord::Base.establish_connection(config)
+      load(File.dirname(__FILE__) + '/../../support/schema.rb')
+      Makara::Context.set_current Makara::Context.generate
     end
 
-    let(:connection) { ActiveRecord::Base.connection }
 
     it 'should have one master and two slaves' do
       expect(connection.master_pool.connection_count).to eq(1)
@@ -71,6 +84,9 @@ describe 'MakaraPostgreSQLAdapter' do
     end
 
     it 'should send reads to the slave' do
+      # ensure the next connection will be the first one
+      connection.slave_pool.instance_variable_set('@current_idx', connection.slave_pool.connections.length)
+
       con = connection.slave_pool.connections.first
       expect(con).to receive(:execute).with('SELECT * FROM users').once
 

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'active_record/connection_adapters/postgresql_adapter'
 
 describe 'MakaraPostgreSQLAdapter' do
 
@@ -28,8 +29,6 @@ describe 'MakaraPostgreSQLAdapter' do
 
   it 'should not blow up if a connection fails' do
     config['makara']['connections'].select{|h| h['role'] == 'slave' }.each{|h| h['username'] = 'other'}
-
-    require 'active_record/connection_adapters/postgresql_adapter'
 
     original_method = ActiveRecord::Base.method(:postgresql_connection)
 

--- a/spec/pool_spec.rb
+++ b/spec/pool_spec.rb
@@ -121,7 +121,11 @@ describe Makara::Pool do
     wrapper_a = pool.add(pool_config){ 'a' }
     wrapper_b = pool.add(pool_config){ 'b' }
 
+    # make the connection
+    pool.send_to_all :to_s
+
     allow(pool).to receive(:next).and_return(wrapper_a, wrapper_b, nil)
+
 
     expect{
       pool.provide do |connection|

--- a/spec/pool_spec.rb
+++ b/spec/pool_spec.rb
@@ -9,8 +9,8 @@ describe Makara::Pool do
   it 'should wrap connections with a ConnectionWrapper as theyre added to the pool' do
     expect(pool.connections).to be_empty
 
-    wrappera = pool.add Proc.new{ 'a'}, pool_config
-    wrapperb = pool.add Proc.new{ 'b'}, pool_config.merge(:weight => 2)
+    wrappera = pool.add(pool_config){ 'a' }
+    wrapperb = pool.add(pool_config.merge(:weight => 2)){ 'b' }
 
     expect(pool.connections.length).to eq(3)
 
@@ -24,8 +24,8 @@ describe Makara::Pool do
 
   it 'should determine if its completely blacklisted' do
 
-    pool.add Proc.new{ 'a'}, pool_config
-    pool.add Proc.new{ 'b'}, pool_config
+    pool.add(pool_config){ 'a' }
+    pool.add(pool_config){ 'b' }
 
     expect(pool).not_to be_completely_blacklisted
 
@@ -39,8 +39,8 @@ describe Makara::Pool do
     a = 'a'
     b = 'b'
 
-    pool.add Proc.new{ a}, pool_config
-    pool.add Proc.new{ b}, pool_config
+    pool.add(pool_config){ a }
+    pool.add(pool_config){ b }
 
     expect(a).to receive(:to_s).once
     expect(b).to receive(:to_s).once
@@ -51,8 +51,8 @@ describe Makara::Pool do
 
   it 'provides the next connection and blacklists' do
 
-    wrapper_a = pool.add Proc.new{ 'a'}, pool_config
-    wrapper_b = pool.add Proc.new{ 'b'}, pool_config
+    wrapper_a = pool.add(pool_config){ 'a' }
+    wrapper_b = pool.add(pool_config){ 'b' }
 
     pool.provide do |connection|
       if connection.to_s == 'a'
@@ -73,8 +73,8 @@ describe Makara::Pool do
   it 'provides the same connection if the context has not changed and the proxy is sticky' do
     allow(proxy).to receive(:sticky){ true }
 
-    pool.add Proc.new{ 'a'}, pool_config
-    pool.add Proc.new{ 'b'}, pool_config
+    pool.add(pool_config){ 'a' }
+    pool.add(pool_config){ 'b' }
 
     provided = []
 
@@ -86,8 +86,8 @@ describe Makara::Pool do
   it 'does not provide the same connection if the proxy is not sticky' do
     allow(proxy).to receive(:sticky){ false }
 
-    pool.add Proc.new{ 'a'}, pool_config
-    pool.add Proc.new{ 'b'}, pool_config
+    pool.add(pool_config){ 'a' }
+    pool.add(pool_config){ 'b' }
 
     provided = []
 
@@ -98,8 +98,8 @@ describe Makara::Pool do
 
   it 'raises an error when all connections are blacklisted' do
 
-    wrapper_a = pool.add Proc.new{ 'a'}, pool_config
-    wrapper_b = pool.add Proc.new{ 'b'}, pool_config
+    wrapper_a = pool.add(pool_config){ 'a' }
+    wrapper_b = pool.add(pool_config){ 'b' }
 
     allow(pool).to receive(:next).and_return(wrapper_a, wrapper_b, nil)
 
@@ -112,10 +112,10 @@ describe Makara::Pool do
 
   it 'skips blacklisted connections when choosing the next one' do
 
-    pool.add Proc.new{ 'a'}, pool_config
-    pool.add Proc.new{ 'c'}, pool_config
+    pool.add(pool_config){ 'a' }
+    pool.add(pool_config){ 'c' }
 
-    wrapper_b = pool.add Proc.new{ 'b'}, pool_config
+    wrapper_b = pool.add(pool_config){ 'b' }
     wrapper_b._makara_blacklist!
 
     10.times{ pool.provide{|connection| expect(connection.to_s).not_to eq('b') } }

--- a/spec/pool_spec.rb
+++ b/spec/pool_spec.rb
@@ -49,6 +49,26 @@ describe Makara::Pool do
 
   end
 
+  it 'only sends methods to underlying objects which are not blacklisted' do
+
+    a = 'a'
+    b = 'b'
+    c = 'c'
+
+    pool.add(pool_config){ a }
+    pool.add(pool_config){ b }
+    wrapper_c = pool.add(pool_config){ c }
+
+    expect(a).to receive(:to_s).once
+    expect(b).to receive(:to_s).once
+    expect(c).to receive(:to_s).never
+
+    wrapper_c._makara_blacklist!
+
+    pool.send_to_all :to_s
+
+  end
+
   it 'provides the next connection and blacklists' do
 
     wrapper_a = pool.add(pool_config){ 'a' }

--- a/spec/pool_spec.rb
+++ b/spec/pool_spec.rb
@@ -9,8 +9,8 @@ describe Makara::Pool do
   it 'should wrap connections with a ConnectionWrapper as theyre added to the pool' do
     expect(pool.connections).to be_empty
 
-    wrappera = pool.add 'a', pool_config
-    wrapperb = pool.add 'b', pool_config.merge(:weight => 2)
+    wrappera = pool.add Proc.new{ 'a'}, pool_config
+    wrapperb = pool.add Proc.new{ 'b'}, pool_config.merge(:weight => 2)
 
     expect(pool.connections.length).to eq(3)
 
@@ -24,8 +24,8 @@ describe Makara::Pool do
 
   it 'should determine if its completely blacklisted' do
 
-    pool.add 'a', pool_config
-    pool.add 'b', pool_config
+    pool.add Proc.new{ 'a'}, pool_config
+    pool.add Proc.new{ 'b'}, pool_config
 
     expect(pool).not_to be_completely_blacklisted
 
@@ -39,8 +39,8 @@ describe Makara::Pool do
     a = 'a'
     b = 'b'
 
-    pool.add a, pool_config
-    pool.add b, pool_config
+    pool.add Proc.new{ a}, pool_config
+    pool.add Proc.new{ b}, pool_config
 
     expect(a).to receive(:to_s).once
     expect(b).to receive(:to_s).once
@@ -51,8 +51,8 @@ describe Makara::Pool do
 
   it 'provides the next connection and blacklists' do
 
-    wrapper_a = pool.add 'a', pool_config
-    wrapper_b = pool.add 'b', pool_config
+    wrapper_a = pool.add Proc.new{ 'a'}, pool_config
+    wrapper_b = pool.add Proc.new{ 'b'}, pool_config
 
     pool.provide do |connection|
       if connection.to_s == 'a'
@@ -73,8 +73,8 @@ describe Makara::Pool do
   it 'provides the same connection if the context has not changed and the proxy is sticky' do
     allow(proxy).to receive(:sticky){ true }
 
-    pool.add 'a', pool_config
-    pool.add 'b', pool_config
+    pool.add Proc.new{ 'a'}, pool_config
+    pool.add Proc.new{ 'b'}, pool_config
 
     provided = []
 
@@ -86,8 +86,8 @@ describe Makara::Pool do
   it 'does not provide the same connection if the proxy is not sticky' do
     allow(proxy).to receive(:sticky){ false }
 
-    pool.add 'a', pool_config
-    pool.add 'b', pool_config
+    pool.add Proc.new{ 'a'}, pool_config
+    pool.add Proc.new{ 'b'}, pool_config
 
     provided = []
 
@@ -98,8 +98,8 @@ describe Makara::Pool do
 
   it 'raises an error when all connections are blacklisted' do
 
-    wrapper_a = pool.add 'a', pool_config
-    wrapper_b = pool.add 'b', pool_config
+    wrapper_a = pool.add Proc.new{ 'a'}, pool_config
+    wrapper_b = pool.add Proc.new{ 'b'}, pool_config
 
     allow(pool).to receive(:next).and_return(wrapper_a, wrapper_b, nil)
 
@@ -112,10 +112,10 @@ describe Makara::Pool do
 
   it 'skips blacklisted connections when choosing the next one' do
 
-    pool.add 'a', pool_config
-    pool.add 'c', pool_config
+    pool.add Proc.new{ 'a'}, pool_config
+    pool.add Proc.new{ 'c'}, pool_config
 
-    wrapper_b = pool.add 'b', pool_config
+    wrapper_b = pool.add Proc.new{ 'b'}, pool_config
     wrapper_b._makara_blacklist!
 
     10.times{ pool.provide{|connection| expect(connection.to_s).not_to eq('b') } }

--- a/spec/proxy_spec.rb
+++ b/spec/proxy_spec.rb
@@ -150,6 +150,8 @@ describe Makara::Proxy do
     end
 
     it 'should raise the error and whitelist all connections if everything is blacklisted (start over)' do
+      proxy.ping
+
       proxy.slave_pool.connections.each(&:_makara_blacklist!)
       proxy.slave_pool.instance_variable_set('@latest_blacklist_error', StandardError.new('some slave connection issue'))
       proxy.master_pool.connections.each(&:_makara_blacklist!)

--- a/spec/proxy_spec.rb
+++ b/spec/proxy_spec.rb
@@ -141,7 +141,7 @@ describe Makara::Proxy do
         if pool == proxy.slave_pool
           test.blacklisting
           pool.instance_variable_set('@latest_blacklist_error', StandardError.new('some connection issue'))
-          pool.send_to_all(:_makara_blacklist!)
+          pool.connections.each(&:_makara_blacklist!)
           pool.provide
         else
           test.using_master

--- a/spec/support/mock_objects.rb
+++ b/spec/support/mock_objects.rb
@@ -1,6 +1,11 @@
 require 'active_record/connection_adapters/makara_abstract_adapter'
 
 class FakeConnection < Struct.new(:config)
+
+  def ping
+    'ping!'
+  end
+
   def irespondtothis
     'hey!'
   end
@@ -27,6 +32,9 @@ class FakeDatabaseAdapter < Struct.new(:config)
 end
 
 class FakeProxy < Makara::Proxy
+
+  send_to_all :ping
+
   def connection_for(config)
     FakeConnection.new(config)
   end

--- a/spec/support/postgresql_database.yml
+++ b/spec/support/postgresql_database.yml
@@ -1,7 +1,7 @@
 test:
   adapter: 'makara_postgresql'
   database: 'makara_test'
-  username: 'mnelson'
+  username: 'root'
   password: ''
 
   makara:


### PR DESCRIPTION
Rather than instantiating connections immediately keep a proc that will do the instantiation. This will allow connections to blow up on instantiation but for the proxy / pool to continue working.
