### PR TITLE
Require makara in makara abstract adapter

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -1,4 +1,5 @@
 require 'active_record'
+require 'makara'
 
 module ActiveRecord
   module ConnectionAdapters


### PR DESCRIPTION
When using rails 4.1.2 release candidates, servers are unable to start because of
an error,

```
uninitialized constant Makara
from /path/to/bundle/ruby/2.1.0/bundler/gems/makara-59b01c0ecfec/lib/active_record/connection_adapters/makara_abstract_adapter.rb:4:in `<module:ActiveRecord>'
from /path/to/bundle/ruby/2.1.0/bundler/gems/makara-59b01c0ecfec/lib/active_record/connection_adapters/makara_abstract_adapter.rb:3:in `<top (required)>'
from /path/to/bundle/ruby/2.1.0/bundler/gems/makara-59b01c0ecfec/lib/active_record/connection_adapters/makara_postgresql_adapter.rb:1:in `<top (required)>'
```

I think that ActiveRecord must be requiring files in some slightly different order
than expected.
